### PR TITLE
feat(autoware.repos): update tier4/pointcloud_to_laserscan to 2.0.0

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -62,7 +62,7 @@ repositories:
   universe/external/pointcloud_to_laserscan:
     type: git
     url: https://github.com/tier4/pointcloud_to_laserscan.git
-    version: tier4/main
+    version: 2.0.0
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git


### PR DESCRIPTION
This PR updates the version of the repository tier4/pointcloud_to_laserscan in autoware.repos