### PR TITLE
feat(autoware.repos): update MapIV/eagleye to v1.2.0

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -66,7 +66,7 @@ repositories:
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git
-    version: autoware-main
+    version: v1.2.0
   universe/external/rtklib_ros_bridge:
     type: git
     url: https://github.com/MapIV/rtklib_ros_bridge.git


### PR DESCRIPTION
This PR updates the version of the repository MapIV/eagleye in autoware.repos