### PR TITLE
feat(autoware.repos): update autowarefoundation/ament_cmake to 1.4.0

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -78,7 +78,7 @@ repositories:
   universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
     type: git
     url: https://github.com/autowarefoundation/ament_cmake.git
-    version: feat/faster_ament_libraries_deduplicate
+    version: 1.4.0
   universe/external/glog:  # TODO(Horibe): to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git


### PR DESCRIPTION
This PR updates the version of the repository autowarefoundation/ament_cmake in autoware.repos