### PR TITLE
feat(autoware.repos): update autowarefoundation/ros2_socketcan to 1.3.0

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -110,7 +110,7 @@ repositories:
   sensor_component/ros2_socketcan:
     type: git
     url: https://github.com/autowarefoundation/ros2_socketcan
-    version: feat/continental_fd
+    version: 1.3.0
   # sensor_kit
   sensor_kit/sample_sensor_kit_launch:
     type: git


### PR DESCRIPTION
This PR updates the version of the repository autowarefoundation/ros2_socketcan in autoware.repos